### PR TITLE
Impossible d'éditer le titre

### DIFF
--- a/zds/poll/forms.py
+++ b/zds/poll/forms.py
@@ -66,7 +66,7 @@ class UpdatePollForm(forms.ModelForm):
 
     class Meta:
         model = Poll
-        fields = ('title', 'activate', 'enddate')
+        fields = ('activate', 'enddate')
         widgets = {
             'enddate': SelectDateWidget()
         }
@@ -77,7 +77,6 @@ class UpdatePollForm(forms.ModelForm):
         self.helper = FormHelper()
 
         self.helper.layout = Layout(
-            Field('title'),
             Field('enddate'),
             Field('activate'),
             ButtonHolder(


### PR DESCRIPTION
Après discussion sur IRC et sur le forum, il semble évident que l'on ne puisse pas modifier le titre d'un sondage. Un exemple ici : https://zestedesavoir.com/forums/sujet/729/zep-09-sondages/?page=3#p98698
