### PR TITLE
[WIP] API : détails d'un sondage

### DIFF
--- a/zds/poll/api/permissions.py
+++ b/zds/poll/api/permissions.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from rest_framework import permissions
+
+
+class AccessUsersPermission(permissions.BasePermission):
+    """
+    if the vote is anonymous : false
+    if the vote isn't anonymous : true
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if obj.poll.anonymous_vote:
+            return False
+        else:
+            return True

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -24,4 +24,4 @@ class PollDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Poll
-        fields = ('pk', 'title', 'enddate', 'choices')
+        fields = ('pk', 'title', 'anonymous_vote', 'type_vote', 'enddate', 'choices')

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
+from rest_framework.fields import CurrentUserDefault
 
 from zds.member.api.serializers import UserListSerializer
-from zds.poll.models import Poll, Choice
+from zds.poll.models import Poll, Choice, Vote
 
 
 class ChoiceSerializer(serializers.ModelSerializer):
@@ -29,3 +30,16 @@ class UsersSerializers(serializers.ModelSerializer):
     class Meta:
         model = Choice
         fields = ('users',)
+
+
+class VoteSerializer(serializers.Serializer):
+
+    class Meta:
+        model = Vote
+
+    def update(self, instance, validated_data):
+        request = self.context.get('request', None)
+        instance.set_user_vote(request.user)
+        instance.save()
+
+        return instance

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -7,16 +7,25 @@ from zds.poll.models import Poll, Choice
 class ChoiceSerializer(serializers.ModelSerializer):
 
     votes = serializers.IntegerField(source='get_count_votes')
-    users = UserListSerializer(source='get_users', many=True, read_only=True)
 
     class Meta:
         model = Choice
-        fields = ('pk', 'choice', 'votes', 'users')
+        fields = ('pk', 'choice', 'votes')
 
 
 class PollDetailSerializer(serializers.ModelSerializer):
+
     choices = ChoiceSerializer(many=True)
 
     class Meta:
         model = Poll
         fields = ('pk', 'title', 'anonymous_vote', 'type_vote', 'enddate', 'choices')
+
+
+class UsersSerializers(serializers.ModelSerializer):
+
+    users = UserListSerializer(source='get_users', many=True, read_only=True)
+
+    class Meta:
+        model = Choice
+        fields = ('users',)

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -1,8 +1,7 @@
 from rest_framework import serializers
-from rest_framework.fields import CurrentUserDefault
 
 from zds.member.api.serializers import UserListSerializer
-from zds.poll.models import Poll, Choice, Vote
+from zds.poll.models import Poll, Choice
 
 
 class ChoiceSerializer(serializers.ModelSerializer):
@@ -30,16 +29,3 @@ class UsersSerializers(serializers.ModelSerializer):
     class Meta:
         model = Choice
         fields = ('users',)
-
-
-class VoteSerializer(serializers.Serializer):
-
-    class Meta:
-        model = Vote
-
-    def update(self, instance, validated_data):
-        request = self.context.get('request', None)
-        instance.set_user_vote(request.user)
-        instance.save()
-
-        return instance

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -14,13 +14,6 @@ class ChoiceSerializer(serializers.ModelSerializer):
         fields = ('pk', 'choice', 'votes', 'users')
 
 
-class PollListSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Poll
-        fields = ('pk', 'title')
-
-
 class PollDetailSerializer(serializers.ModelSerializer):
     choices = ChoiceSerializer(many=True)
 

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -1,15 +1,17 @@
 from rest_framework import serializers
 
+from zds.member.api.serializers import UserListSerializer
 from zds.poll.models import Poll, Choice
 
 
 class ChoiceSerializer(serializers.ModelSerializer):
 
     votes = serializers.IntegerField(source='get_count_votes')
+    users = UserListSerializer(source='get_users', many=True, read_only=True)
 
     class Meta:
         model = Choice
-        fields = ('pk', 'choice', 'votes')
+        fields = ('pk', 'choice', 'votes', 'users')
 
 
 class PollListSerializer(serializers.ModelSerializer):

--- a/zds/poll/api/serializers.py
+++ b/zds/poll/api/serializers.py
@@ -5,9 +5,11 @@ from zds.poll.models import Poll, Choice
 
 class ChoiceSerializer(serializers.ModelSerializer):
 
+    votes = serializers.IntegerField(source='get_count_votes')
+
     class Meta:
         model = Choice
-        fields = ('pk', 'choice')
+        fields = ('pk', 'choice', 'votes')
 
 
 class PollListSerializer(serializers.ModelSerializer):
@@ -22,4 +24,4 @@ class PollDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Poll
-        fields = ('pk', 'title', 'choices')
+        fields = ('pk', 'title', 'enddate', 'choices')

--- a/zds/poll/api/urls.py
+++ b/zds/poll/api/urls.py
@@ -2,9 +2,8 @@
 
 from django.conf.urls import url
 
-from zds.poll.api.views import PollListAPIView, PollDetailAPIView
+from zds.poll.api.views import PollDetailAPIView
 
 urlpatterns = [
-    url(r'^$', PollListAPIView.as_view(), name='list'),
     url(r'^(?P<pk>[0-9]+)/$', PollDetailAPIView.as_view(), name='detail'),
 ]

--- a/zds/poll/api/urls.py
+++ b/zds/poll/api/urls.py
@@ -2,8 +2,9 @@
 
 from django.conf.urls import url
 
-from zds.poll.api.views import PollDetailAPIView
+from zds.poll.api.views import PollDetailAPIView, UsersDetailAPIView
 
 urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', PollDetailAPIView.as_view(), name='detail'),
+    url(r'^choix/(?P<pk>[0-9]+)/$', UsersDetailAPIView.as_view(), name='detail'),
 ]

--- a/zds/poll/api/urls.py
+++ b/zds/poll/api/urls.py
@@ -2,9 +2,10 @@
 
 from django.conf.urls import url
 
-from zds.poll.api.views import PollDetailAPIView, UsersDetailAPIView
+from zds.poll.api.views import PollDetailAPIView, UsersDetailAPIView, VoteAPIView
 
 urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', PollDetailAPIView.as_view(), name='detail'),
     url(r'^choix/(?P<pk>[0-9]+)/$', UsersDetailAPIView.as_view(), name='detail'),
+    url(r'^vote/(?P<pk>[0-9]+)/$', VoteAPIView.as_view(), name='vote'),
 ]

--- a/zds/poll/api/urls.py
+++ b/zds/poll/api/urls.py
@@ -2,10 +2,9 @@
 
 from django.conf.urls import url
 
-from zds.poll.api.views import PollDetailAPIView, UsersDetailAPIView, VoteAPIView
+from zds.poll.api.views import PollDetailAPIView, UsersDetailAPIView
 
 urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/$', PollDetailAPIView.as_view(), name='detail'),
     url(r'^choix/(?P<pk>[0-9]+)/$', UsersDetailAPIView.as_view(), name='detail'),
-    url(r'^vote/(?P<pk>[0-9]+)/$', VoteAPIView.as_view(), name='vote'),
 ]

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from rest_framework.generics import RetrieveAPIView
+from rest_framework.generics import RetrieveAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.renderers import JSONRenderer
 
-from zds.poll.api.serializers import PollDetailSerializer, UsersSerializers
+from zds.poll.api.serializers import PollDetailSerializer, UsersSerializers, VoteSerializer
 from zds.poll.models import Poll, Choice
 from zds.poll.api.permissions import AccessUsersPermission
 
@@ -22,3 +22,11 @@ class UsersDetailAPIView(RetrieveAPIView):
     queryset = Choice.objects.all()
     serializer_class = UsersSerializers
     renderer_classes = (JSONRenderer,)
+
+
+class VoteAPIView(RetrieveUpdateDestroyAPIView):
+
+    queryset = Choice.objects.all()
+    serializer_class = VoteSerializer
+    renderer_classes = (JSONRenderer,)
+

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -19,5 +19,3 @@ class PollDetailAPIView(RetrieveAPIView):
     serializer_class = PollDetailSerializer
     renderer_classes = (JSONRenderer,)
 
-    def get(self, request, *args, **kwargs):
-        return self.retrieve(request, *args, **kwargs)

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -1,16 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.generics import RetrieveAPIView
 from rest_framework.renderers import JSONRenderer
 
-from zds.poll.api.serializers import PollListSerializer, PollDetailSerializer
+from zds.poll.api.serializers import PollDetailSerializer
 from zds.poll.models import Poll
-
-
-class PollListAPIView(ListAPIView):
-    serializer_class = PollListSerializer
-    queryset = Poll.objects.all()
 
 
 class PollDetailAPIView(RetrieveAPIView):

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -6,6 +6,7 @@ from rest_framework.renderers import JSONRenderer
 
 from zds.poll.api.serializers import PollDetailSerializer, UsersSerializers
 from zds.poll.models import Poll, Choice
+from zds.poll.api.permissions import AccessUsersPermission
 
 
 class PollDetailAPIView(RetrieveAPIView):
@@ -17,5 +18,7 @@ class PollDetailAPIView(RetrieveAPIView):
 
 class UsersDetailAPIView(RetrieveAPIView):
 
+    permission_classes = (AccessUsersPermission,)
     queryset = Choice.objects.all()
     serializer_class = UsersSerializers
+    renderer_classes = (JSONRenderer,)

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from rest_framework.generics import RetrieveAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import RetrieveAPIView
 from rest_framework.renderers import JSONRenderer
 
-from zds.poll.api.serializers import PollDetailSerializer, UsersSerializers, VoteSerializer
+from zds.poll.api.serializers import PollDetailSerializer, UsersSerializers
 from zds.poll.models import Poll, Choice
 from zds.poll.api.permissions import AccessUsersPermission
 
@@ -22,11 +22,3 @@ class UsersDetailAPIView(RetrieveAPIView):
     queryset = Choice.objects.all()
     serializer_class = UsersSerializers
     renderer_classes = (JSONRenderer,)
-
-
-class VoteAPIView(RetrieveUpdateDestroyAPIView):
-
-    queryset = Choice.objects.all()
-    serializer_class = VoteSerializer
-    renderer_classes = (JSONRenderer,)
-

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -4,8 +4,8 @@
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.renderers import JSONRenderer
 
-from zds.poll.api.serializers import PollDetailSerializer
-from zds.poll.models import Poll
+from zds.poll.api.serializers import PollDetailSerializer, UsersSerializers
+from zds.poll.models import Poll, Choice
 
 
 class PollDetailAPIView(RetrieveAPIView):
@@ -14,3 +14,8 @@ class PollDetailAPIView(RetrieveAPIView):
     serializer_class = PollDetailSerializer
     renderer_classes = (JSONRenderer,)
 
+
+class UsersDetailAPIView(RetrieveAPIView):
+
+    queryset = Choice.objects.all()
+    serializer_class = UsersSerializers

--- a/zds/poll/api/views.py
+++ b/zds/poll/api/views.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.renderers import JSONRenderer
 
 from zds.poll.api.serializers import PollListSerializer, PollDetailSerializer
 from zds.poll.models import Poll
@@ -13,5 +14,10 @@ class PollListAPIView(ListAPIView):
 
 
 class PollDetailAPIView(RetrieveAPIView):
-    serializer_class = PollDetailSerializer
+
     queryset = Poll.objects.all()
+    serializer_class = PollDetailSerializer
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)

--- a/zds/poll/models.py
+++ b/zds/poll/models.py
@@ -138,6 +138,9 @@ class Choice(models.Model):
         """
         return [Vote.user for Vote in self.poll.get_vote_class().objects.filter(choice=self, poll=self.poll)]
 
+    def set_user_vote(self, user):
+        UniqueVote.objects.update_or_create(user=user, choice=self, poll=self.poll)
+
 
 class Vote(models.Model):
 

--- a/zds/poll/models.py
+++ b/zds/poll/models.py
@@ -131,6 +131,13 @@ class Choice(models.Model):
         count = self.poll.get_vote_class().objects.filter(choice=self, poll=self.poll).count()
         return count
 
+    def get_users(self):
+        """
+        :return: Users
+        :rtype a dict
+        """
+        return [Vote.user for Vote in self.poll.get_vote_class().objects.filter(choice=self, poll=self.poll)]
+
 
 class Vote(models.Model):
 

--- a/zds/poll/models.py
+++ b/zds/poll/models.py
@@ -138,9 +138,6 @@ class Choice(models.Model):
         """
         return [Vote.user for Vote in self.poll.get_vote_class().objects.filter(choice=self, poll=self.poll)]
 
-    def set_user_vote(self, user):
-        UniqueVote.objects.update_or_create(user=user, choice=self, poll=self.poll)
-
 
 class Vote(models.Model):
 

--- a/zds/poll/models.py
+++ b/zds/poll/models.py
@@ -134,7 +134,7 @@ class Choice(models.Model):
     def get_users(self):
         """
         :return: Users
-        :rtype a dict
+        :rtype a list
         """
         return [Vote.user for Vote in self.poll.get_vote_class().objects.filter(choice=self, poll=self.poll)]
 


### PR DESCRIPTION
Cette PR construit les différentes vues afin de récupérer toutes les informations utiles sur un sondage donné.

La vue `api/sondages/[pk]` renvoie le titre du sondage, son type de vote, si il est anonyme ou non, sa date de clotûre, ainsi que les différents choix disponibles. Pour chaque choix, le `pk` associé et le nombre de votes sont également présents. Exemple ci-dessous : 

``` json
{
      "pk": 1,
      "title": "Nancy ou Metz ?",
      "anonymous_vote": false,
      "type_vote": "u",
      "enddate": "2017-02-03T00:00:00",
      "choices":
      [
          {
              "pk": 1,
              "choice": "Nancy",
              "votes": 1
          },
          {
              "pk": 2,
              "choice": "Metz",
              "votes": 0
          }
      ]
  }
```

Dans le cas d'un sondage non-anonyme, il doit également être possible de récupérer la liste des utilisateurs ayant voté. Pour cela, la vue `api/sondages/choix/[pk]` (l'URL est peut-être à changer, qu'en pensez vous ?) renvoie la liste des utilisateurs ayant voté pour un choix donné. Évidemment, cette vue est uniquement accessible si le vote est non-anonyme. Exemple ci-dessous : 

``` json
{
  "users": [
    {
      "id": 1,
      "username": "admin",
      "html_url": "/membres/voir/admin/",
      "is_active": true,
      "date_joined": "2016-06-06T15:38:31.846540",
      "avatar_url": "https://secure.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?d=identicon"
    }
  ]
}
```
